### PR TITLE
Add branch status to basic lines data

### DIFF
--- a/src/main/java/org/gridsuite/network/map/NetworkMapService.java
+++ b/src/main/java/org/gridsuite/network/map/NetworkMapService.java
@@ -163,6 +163,10 @@ class NetworkMapService {
         if (limits2 != null && !Double.isNaN(limits2.getPermanentLimit())) {
             builder.permanentLimit2(limits2.getPermanentLimit());
         }
+        BranchStatus<Line> branchStatus = line.getExtension(BranchStatus.class);
+        if (branchStatus != null) {
+            builder.branchStatus(branchStatus.getStatus().name());
+        }
         return builder.build();
     }
 

--- a/src/test/resources/map-lines-data.json
+++ b/src/test/resources/map-lines-data.json
@@ -28,6 +28,7 @@
     "voltageLevelName1": null,
     "voltageLevelName2": null,
     "terminal1Connected":true,
-    "terminal2Connected":true
+    "terminal2Connected":true,
+    "branchStatus": "PLANNED_OUTAGE"
   }
 ]

--- a/src/test/resources/partial-map-lines-data.json
+++ b/src/test/resources/partial-map-lines-data.json
@@ -28,6 +28,7 @@
     "voltageLevelName1": null,
     "voltageLevelName2": null,
     "terminal1Connected":true,
-    "terminal2Connected":true
+    "terminal2Connected":true,
+    "branchStatus": "PLANNED_OUTAGE"
   }
 ]


### PR DESCRIPTION
Branch status is missing to basic lines data to display status icon on the map.

Signed-off-by: HOMER Etienne <etiennehomer@gmail.com>