### PR TITLE
use nullIfNan for regulationValue from TapChangerData data

### DIFF
--- a/src/main/java/org/gridsuite/network/map/dto/utils/ElementUtils.java
+++ b/src/main/java/org/gridsuite/network/map/dto/utils/ElementUtils.java
@@ -213,6 +213,7 @@ public final class ElementUtils {
                 .steps(toMapDataPhaseStep(tapChanger.getAllSteps()));
 
         builder.targetDeadband(nullIfNan(tapChanger.getTargetDeadband()));
+        builder.regulationValue(nullIfNan(tapChanger.getRegulationValue()));
         return builder.build();
     }
 


### PR DESCRIPTION
When regulationValue is equal to NaN in the database it is added normally in the network json. It shouldn't. This PR turns regulationValue NaN into null and therefore  doesn't add them to the json.