### PR TITLE
Fix empty list handling in controller

### DIFF
--- a/src/main/java/org/gridsuite/network/map/NetworkMapController.java
+++ b/src/main/java/org/gridsuite/network/map/NetworkMapController.java
@@ -12,12 +12,18 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import org.gridsuite.network.map.dto.*;
+import org.gridsuite.network.map.dto.AllElementsInfos;
+import org.gridsuite.network.map.dto.ElementInfos;
+import org.gridsuite.network.map.dto.ElementType;
+import org.gridsuite.network.map.dto.InfoTypeParameters;
 import org.gridsuite.network.map.dto.definition.hvdc.HvdcShuntCompensatorsInfos;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.*;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
 
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
@@ -46,9 +52,8 @@ public class NetworkMapController {
                                        @Parameter(description = "Variant Id") @RequestParam(name = "variantId", required = false) String variantId,
                                        @Parameter(description = "Nominal Voltages") @RequestParam(name = "nominalVoltages", required = false) List<Double> nominalVoltages,
                                        @Parameter(description = "Element type") @RequestParam(name = "elementType") ElementType elementType,
-                                       @RequestBody(required = false) List<String> substationsIds
-                                       ) {
-        return networkMapService.getElementsIds(networkUuid, variantId, substationsIds, elementType, nominalVoltages);
+                                       @RequestBody(required = false) Optional<List<String>> substationsIds) {
+        return networkMapService.getElementsIds(networkUuid, variantId, substationsIds.orElseGet(List::of), elementType, nominalVoltages);
     }
 
     @GetMapping(value = "/networks/{networkUuid}/all", produces = APPLICATION_JSON_VALUE)
@@ -56,7 +61,7 @@ public class NetworkMapController {
     @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "all equipments descriptions")})
     public AllElementsInfos getAll(@Parameter(description = "Network UUID") @PathVariable("networkUuid") UUID networkUuid,
                                    @Parameter(description = "Variant Id") @RequestParam(name = "variantId", required = false) String variantId,
-                                   @Parameter(description = "Substations id") @RequestParam(name = "substationId", required = false) List<String> substationsIds) {
+                                   @Parameter(description = "Substations id") @RequestParam(name = "substationId", defaultValue = "") List<String> substationsIds) {
         return networkMapService.getAllElementsInfos(networkUuid, variantId, substationsIds);
     }
 
@@ -68,8 +73,8 @@ public class NetworkMapController {
                                                @Parameter(description = "Nominal Voltages") @RequestParam(name = "nominalVoltages", required = false) List<Double> nominalVoltages,
                                                @Parameter(description = "Element type") @RequestParam(name = "elementType") ElementType elementType,
                                                @Parameter(description = "Info type parameters") InfoTypeParameters infoTypeParameters,
-                                               @RequestBody(required = false) List<String> substationsIds) {
-        return networkMapService.getElementsInfos(networkUuid, variantId, substationsIds, elementType, infoTypeParameters, nominalVoltages);
+                                               @RequestBody(required = false) Optional<List<String>> substationsIds) {
+        return networkMapService.getElementsInfos(networkUuid, variantId, substationsIds.orElseGet(List::of), elementType, infoTypeParameters, nominalVoltages);
     }
 
     @GetMapping(value = "/networks/{networkUuid}/elements/{elementId}", produces = APPLICATION_JSON_VALUE)
@@ -116,7 +121,7 @@ public class NetworkMapController {
     public List<ElementInfos> getVoltageLevelEquipments(@Parameter(description = "Network UUID") @PathVariable("networkUuid") UUID networkUuid,
                                                                @Parameter(description = "Voltage level id") @PathVariable("voltageLevelId") String voltageLevelId,
                                                                @Parameter(description = "Variant Id") @RequestParam(name = "variantId", required = false) String variantId,
-                                                               @Parameter(description = "Substations id") @RequestParam(name = "substationId", required = false) List<String> substationsIds) {
+                                                               @Parameter(description = "Substations id") @RequestParam(name = "substationId", defaultValue = "") List<String> substationsIds) {
         return networkMapService.getVoltageLevelEquipments(networkUuid, voltageLevelId, variantId, substationsIds);
     }
 
@@ -159,8 +164,8 @@ public class NetworkMapController {
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "Nominal voltages are found the in voltage levels of the network")
     })
-    public @ResponseBody List<Double> getNominalVoltages(@Parameter(description = "Network UUID") @PathVariable("networkUuid") UUID networkUuid,
-                                                   @Parameter(description = "Variant ID") @RequestParam(name = "variantId", required = false) String variantId) {
+    public List<Double> getNominalVoltages(@Parameter(description = "Network UUID") @PathVariable("networkUuid") UUID networkUuid,
+                                           @Parameter(description = "Variant ID") @RequestParam(name = "variantId", required = false) String variantId) {
         return networkMapService.getNominalVoltages(networkUuid, variantId).stream().sorted().toList();
     }
 }

--- a/src/main/java/org/gridsuite/network/map/NetworkMapService.java
+++ b/src/main/java/org/gridsuite/network/map/NetworkMapService.java
@@ -10,12 +10,16 @@ import com.powsybl.commons.PowsyblException;
 import com.powsybl.iidm.network.*;
 import com.powsybl.network.store.client.NetworkStoreService;
 import com.powsybl.network.store.client.PreloadingStrategy;
-import org.gridsuite.network.map.dto.*;
+import org.gridsuite.network.map.dto.AllElementsInfos;
+import org.gridsuite.network.map.dto.ElementInfos;
+import org.gridsuite.network.map.dto.ElementType;
+import org.gridsuite.network.map.dto.InfoTypeParameters;
 import org.gridsuite.network.map.dto.definition.hvdc.HvdcShuntCompensatorsInfos;
 import org.gridsuite.network.map.dto.mapper.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.http.HttpStatus;
+import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
 
@@ -46,8 +50,8 @@ public class NetworkMapService {
         }
     }
 
-    private PreloadingStrategy getPreloadingStrategy(List<String> substationsIds) {
-        return substationsIds == null ? PreloadingStrategy.COLLECTION : PreloadingStrategy.NONE;
+    private static PreloadingStrategy getPreloadingStrategy(@NonNull List<String> substationsIds) {
+        return substationsIds.isEmpty() ? PreloadingStrategy.COLLECTION : PreloadingStrategy.NONE;
     }
 
     public List<String> getSubstationsIds(UUID networkUuid, String variantId, List<Double> nominalVoltages) {
@@ -58,7 +62,7 @@ public class NetworkMapService {
                 .map(Substation::getId).toList();
     }
 
-    public AllElementsInfos getAllElementsInfos(UUID networkUuid, String variantId, List<String> substationsId) {
+    public AllElementsInfos getAllElementsInfos(UUID networkUuid, String variantId, @NonNull List<String> substationsId) {
         Network network = getNetwork(networkUuid, PreloadingStrategy.COLLECTION, variantId);
         return AllElementsInfos.builder()
                 .substations(getSubstationsInfos(network, substationsId, InfoTypeParameters.TAB, null))
@@ -80,14 +84,14 @@ public class NetworkMapService {
                 .build();
     }
 
-    public List<String> getVoltageLevelsIds(UUID networkUuid, String variantId, List<String> substationsIds, List<Double> nominalVoltages) {
+    private List<String> getVoltageLevelsIds(UUID networkUuid, String variantId, @NonNull List<String> substationsIds, List<Double> nominalVoltages) {
         Network network = getNetwork(networkUuid, getPreloadingStrategy(substationsIds), variantId);
         return getVoltageLevelStream(network, substationsIds, nominalVoltages).map(VoltageLevel::getId).toList();
     }
 
-    public List<ElementInfos> getVoltageLevelEquipments(UUID networkUuid, String voltageLevelId, String variantId, List<String> substationsId) {
+    public List<ElementInfos> getVoltageLevelEquipments(UUID networkUuid, String voltageLevelId, String variantId, @NonNull List<String> substationsId) {
         Network network = getNetwork(networkUuid, getPreloadingStrategy(substationsId), variantId);
-        List<VoltageLevel> voltageLevels = substationsId == null ?
+        List<VoltageLevel> voltageLevels = substationsId.isEmpty() ?
                 List.of(network.getVoltageLevel(voltageLevelId)) :
                 substationsId.stream().flatMap(id -> network.getSubstation(id).getVoltageLevelStream().filter(voltageLevel -> voltageLevelId.equals(voltageLevel.getId()))).toList();
 
@@ -115,9 +119,9 @@ public class NetworkMapService {
                 .map(BusbarSection::getId).collect(Collectors.toList());
     }
 
-    public List<String> getHvdcLinesIds(UUID networkUuid, String variantId, List<String> substationsIds, List<Double> nominalVoltages) {
+    private List<String> getHvdcLinesIds(UUID networkUuid, String variantId, @NonNull List<String> substationsIds, List<Double> nominalVoltages) {
         Network network = getNetwork(networkUuid, getPreloadingStrategy(substationsIds), variantId);
-        if (substationsIds == null && nominalVoltages == null) {
+        if (substationsIds.isEmpty() && nominalVoltages == null) {
             return network.getHvdcLineStream()
                     .map(HvdcLine::getId).toList();
         } else {
@@ -131,9 +135,9 @@ public class NetworkMapService {
         }
     }
 
-    public List<String> getTieLinesIds(UUID networkUuid, String variantId, List<String> substationsIds, List<Double> nominalVoltages) {
+    private List<String> getTieLinesIds(UUID networkUuid, String variantId, @NonNull List<String> substationsIds, List<Double> nominalVoltages) {
         Network network = getNetwork(networkUuid, getPreloadingStrategy(substationsIds), variantId);
-        if (substationsIds == null && nominalVoltages == null) {
+        if (substationsIds.isEmpty() && nominalVoltages == null) {
             return network.getTieLineStream()
                     .map(TieLine::getId).toList();
         } else {
@@ -147,8 +151,8 @@ public class NetworkMapService {
         }
     }
 
-    private List<ElementInfos> getSubstationsInfos(Network network, List<String> substationsId, InfoTypeParameters infoTypeParameters, List<Double> nominalVoltages) {
-        Stream<Substation> substations = substationsId == null ? network.getSubstationStream() : substationsId.stream().map(network::getSubstation);
+    private List<ElementInfos> getSubstationsInfos(Network network, @NonNull List<String> substationsId, InfoTypeParameters infoTypeParameters, List<Double> nominalVoltages) {
+        Stream<Substation> substations = substationsId.isEmpty() ? network.getSubstationStream() : substationsId.stream().map(network::getSubstation);
         return substations
                 .filter(substation -> nominalVoltages == null ||
                         substation.getVoltageLevelStream().anyMatch(voltageLevel -> nominalVoltages.contains(voltageLevel.getNominalV())))
@@ -156,14 +160,14 @@ public class NetworkMapService {
                 .toList();
     }
 
-    public List<ElementInfos> getVoltageLevelsInfos(Network network, List<String> substationsId, InfoTypeParameters infoTypeParameters, List<Double> nominalVoltages) {
+    private List<ElementInfos> getVoltageLevelsInfos(Network network, @NonNull List<String> substationsId, InfoTypeParameters infoTypeParameters, List<Double> nominalVoltages) {
         return getVoltageLevelStream(network, substationsId, nominalVoltages)
                 .map(c -> ElementType.VOLTAGE_LEVEL.getInfosGetter().apply(c, infoTypeParameters))
                 .toList();
     }
 
-    public List<ElementInfos> getHvdcLinesInfos(Network network, List<String> substationsId, InfoTypeParameters infoTypeParameters, List<Double> nominalVoltages) {
-        Stream<HvdcLine> hvdcLines = substationsId == null ? network.getHvdcLineStream() :
+    private List<ElementInfos> getHvdcLinesInfos(Network network, @NonNull List<String> substationsId, InfoTypeParameters infoTypeParameters, List<Double> nominalVoltages) {
+        Stream<HvdcLine> hvdcLines = substationsId.isEmpty() ? network.getHvdcLineStream() :
                 substationsId.stream()
                         .map(network::getSubstation)
                         .flatMap(Substation::getVoltageLevelStream)
@@ -178,8 +182,8 @@ public class NetworkMapService {
                 .toList();
     }
 
-    public List<ElementInfos> getTieLinesInfos(Network network, List<String> substationsId, InfoTypeParameters infoTypeParameters, List<Double> nominalVoltages) {
-        Stream<TieLine> tieLines = substationsId == null ? network.getTieLineStream() :
+    private List<ElementInfos> getTieLinesInfos(Network network, @NonNull List<String> substationsId, InfoTypeParameters infoTypeParameters, List<Double> nominalVoltages) {
+        Stream<TieLine> tieLines = substationsId.isEmpty() ? network.getTieLineStream() :
                 substationsId.stream()
                         .map(network::getSubstation)
                         .flatMap(Substation::getVoltageLevelStream)
@@ -194,8 +198,8 @@ public class NetworkMapService {
                 .toList();
     }
 
-    public List<ElementInfos> getBusesInfos(Network network, List<String> substationsId, InfoTypeParameters infoTypeParameters) {
-        Stream<Bus> buses = substationsId == null ? network.getBusView().getBusStream() :
+    private List<ElementInfos> getBusesInfos(Network network, @NonNull List<String> substationsId, InfoTypeParameters infoTypeParameters) {
+        Stream<Bus> buses = substationsId.isEmpty() ? network.getBusView().getBusStream() :
                 network.getBusView().getBusStream()
                         .filter(bus -> bus.getVoltageLevel().getSubstation().stream().anyMatch(substation -> substationsId.contains(substation.getId())))
                         .filter(Objects::nonNull)
@@ -206,9 +210,9 @@ public class NetworkMapService {
                 .toList();
     }
 
-    private List<ElementInfos> getElementsInfos(Network network, List<String> substationsIds, ElementType elementType, InfoTypeParameters infoTypeParameters, List<Double> nominalVoltages) {
+    private List<ElementInfos> getElementsInfos(Network network, @NonNull List<String> substationsIds, ElementType elementType, InfoTypeParameters infoTypeParameters, List<Double> nominalVoltages) {
         Class<? extends Connectable> elementClass = (Class<? extends Connectable>) elementType.getElementClass();
-        Stream<? extends Connectable> connectables = substationsIds == null ?
+        Stream<? extends Connectable> connectables = substationsIds.isEmpty() ?
                 getConnectableStream(network, elementType) :
                 substationsIds.stream()
                         .flatMap(substationId -> network.getSubstation(substationId).getVoltageLevelStream())
@@ -220,7 +224,7 @@ public class NetworkMapService {
                 .collect(Collectors.toList());
     }
 
-    public List<ElementInfos> getElementsInfos(UUID networkUuid, String variantId, List<String> substationsIds, ElementType equipmentType, InfoTypeParameters infoTypeParameters, List<Double> nominalVoltages) {
+    public List<ElementInfos> getElementsInfos(UUID networkUuid, String variantId, @NonNull List<String> substationsIds, ElementType equipmentType, InfoTypeParameters infoTypeParameters, List<Double> nominalVoltages) {
         Network network = getNetwork(networkUuid, getPreloadingStrategy(substationsIds), variantId);
         switch (equipmentType) {
             case SUBSTATION:
@@ -275,7 +279,7 @@ public class NetworkMapService {
         return HvdcInfosMapper.toHvdcShuntCompensatorsInfos(hvdcLine);
     }
 
-    public List<String> getElementsIds(UUID networkUuid, String variantId, List<String> substationsIds, ElementType elementType, List<Double> nominalVoltages) {
+    public List<String> getElementsIds(UUID networkUuid, String variantId, @NonNull List<String> substationsIds, ElementType elementType, List<Double> nominalVoltages) {
         switch (elementType) {
             case SUBSTATION:
                 return getSubstationsIds(networkUuid, variantId, nominalVoltages);
@@ -290,9 +294,9 @@ public class NetworkMapService {
         }
     }
 
-    private List<String> getConnectablesIds(UUID networkUuid, String variantId, List<String> substationsIds, ElementType elementType, List<Double> nominalVoltages) {
+    private List<String> getConnectablesIds(UUID networkUuid, String variantId, @NonNull List<String> substationsIds, ElementType elementType, List<Double> nominalVoltages) {
         Network network = getNetwork(networkUuid, getPreloadingStrategy(substationsIds), variantId);
-        if (substationsIds == null && nominalVoltages == null) {
+        if (substationsIds.isEmpty() && nominalVoltages == null) {
             return getConnectableStream(network, elementType)
                     .map(Connectable::getId)
                     .toList();
@@ -305,9 +309,9 @@ public class NetworkMapService {
         }
     }
 
-    private Stream<VoltageLevel> getVoltageLevelStream(Network network, List<String> substationsIds, List<Double> nominalVoltages) {
+    private Stream<VoltageLevel> getVoltageLevelStream(Network network, @NonNull List<String> substationsIds, List<Double> nominalVoltages) {
         Stream<VoltageLevel> voltageLevelStream =
-                substationsIds == null ?
+                substationsIds.isEmpty() ?
                         network.getVoltageLevelStream() :
                         substationsIds.stream().flatMap(substationId -> network.getSubstation(substationId).getVoltageLevelStream());
         return voltageLevelStream.filter(voltageLevel -> nominalVoltages == null || nominalVoltages.contains(voltageLevel.getNominalV()));

--- a/src/main/java/org/gridsuite/network/map/dto/InfoTypeParameters.java
+++ b/src/main/java/org/gridsuite/network/map/dto/InfoTypeParameters.java
@@ -6,14 +6,12 @@
  */
 package org.gridsuite.network.map.dto;
 
-import lombok.Getter;
-import lombok.Setter;
+import lombok.Data;
 
 import java.util.HashMap;
 import java.util.Map;
 
-@Getter
-@Setter
+@Data
 public class InfoTypeParameters {
     public static final String QUERY_PARAM_DC_POWERFACTOR = "dcPowerFactor";
     public static final String QUERY_PARAM_OPERATION = "operation";

--- a/src/test/java/org/gridsuite/network/map/ListHandlingControllerTest.java
+++ b/src/test/java/org/gridsuite/network/map/ListHandlingControllerTest.java
@@ -1,0 +1,105 @@
+/* Copyright (c) 2024, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.gridsuite.network.map;
+
+import org.gridsuite.network.map.dto.ElementType;
+import org.gridsuite.network.map.dto.InfoTypeParameters;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+
+import java.util.*;
+import java.util.stream.Stream;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Tests to assure the {@link NetworkMapController} handle empty {@link List} and {@code null} values the same in endpoints parameters.
+ */
+@SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+@WebMvcTest(controllers = NetworkMapController.class)
+class ListHandlingControllerTest {
+    private static final UUID NETWORK_ID = UUID.randomUUID();
+
+    @Autowired
+    private MockMvc mvc;
+
+    @MockBean
+    private NetworkMapService networkMapService;
+
+    @BeforeEach
+    void setUp() {
+        Mockito.verifyNoInteractions(networkMapService);
+    }
+
+    @AfterEach
+    void setDown() {
+        Mockito.verifyNoMoreInteractions(networkMapService);
+    }
+
+    @AfterAll
+    static void tearDown() {
+        Mockito.validateMockitoUsage();
+    }
+
+    private static Stream<Optional<String>> testParameterList() {
+        return Stream.of(Optional.empty(), Optional.of(""));
+    }
+
+    private MockHttpServletRequestBuilder requestWithOptionalSubstationId(final MockHttpServletRequestBuilder requestBuilder, final Optional<String> parameter) {
+        return parameter.map(s -> requestBuilder.queryParam("substationId", s)).orElse(requestBuilder);
+    }
+
+    /** Case of {@code substationId} for {@link NetworkMapController#getVoltageLevelEquipments(UUID, String, String, List)} */
+    @ParameterizedTest
+    @MethodSource("testParameterList")
+    void getVoltageLevelEquipmentsSubstationsIds(final Optional<String> parameter) throws Exception {
+        mvc.perform(requestWithOptionalSubstationId(get("/v1/networks/{networkUuid}/voltage-levels/{voltageLevelId}/equipments", NETWORK_ID, "testId"), parameter))
+            .andExpect(status().is2xxSuccessful());
+        verify(networkMapService).getVoltageLevelEquipments(eq(NETWORK_ID), eq("testId"), isNull(), eq(Collections.emptyList()));
+    }
+
+    /** Case of {@code substationId} for {@link NetworkMapController#getAll(UUID, String, List)} */
+    @ParameterizedTest
+    @MethodSource("testParameterList")
+    void getAllSubstationsIds(final Optional<String> parameter) throws Exception {
+        mvc.perform(requestWithOptionalSubstationId(get("/v1/networks/{networkUuid}/all", NETWORK_ID), parameter))
+            .andExpect(status().is2xxSuccessful());
+        verify(networkMapService).getAllElementsInfos(eq(NETWORK_ID), isNull(), eq(Collections.emptyList()));
+    }
+
+    /** Case of {@code substationsIds} for {@link NetworkMapController#getElementsInfos(UUID, String, List, ElementType, InfoTypeParameters, Optional)} */
+    @ParameterizedTest
+    @MethodSource("testParameterList")
+    void getElementsInfosSubstationsIds(final Optional<String> parameter) throws Exception {
+        mvc.perform(requestWithOptionalSubstationId(post("/v1/networks/{networkUuid}/elements", NETWORK_ID)
+                .queryParam("elementType", ElementType.LINE.toString()), parameter))
+            .andExpect(status().is2xxSuccessful());
+        verify(networkMapService).getElementsInfos(eq(NETWORK_ID), isNull(), eq(Collections.emptyList()), same(ElementType.LINE), eq(new InfoTypeParameters(null, Map.of())), isNull());
+    }
+
+    /** Case of {@code substationsIds} for {@link NetworkMapController#getElementsIds(UUID, String, List, ElementType, Optional)} */
+    @ParameterizedTest
+    @MethodSource("testParameterList")
+    void getElementsIdsSubstationsIds(final Optional<String> parameter) throws Exception {
+        mvc.perform(requestWithOptionalSubstationId(post("/v1/networks/{networkUuid}/elements-ids", NETWORK_ID)
+                .queryParam("elementType", ElementType.LINE.toString()), parameter))
+            .andExpect(status().is2xxSuccessful());
+        verify(networkMapService).getElementsIds(eq(NETWORK_ID), isNull(), eq(Collections.emptyList()), same(ElementType.LINE), isNull());
+    }
+}

--- a/src/test/java/org/gridsuite/network/map/NetworkMapControllerTest.java
+++ b/src/test/java/org/gridsuite/network/map/NetworkMapControllerTest.java
@@ -18,9 +18,10 @@ import com.powsybl.network.store.client.PreloadingStrategy;
 import com.powsybl.network.store.iidm.impl.NetworkFactoryImpl;
 import org.gridsuite.network.map.dto.ElementInfos.InfoType;
 import org.gridsuite.network.map.dto.ElementType;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.MockitoAnnotations;
+import org.mockito.Mockito;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -83,8 +84,6 @@ class NetworkMapControllerTest {
 
     @BeforeEach
     void setUp() {
-        MockitoAnnotations.initMocks(this);
-
         Network network = EurostagTutorialExample1Factory.createWithMoreGenerators(new NetworkFactoryImpl());
         Line l2 = network.getLine("NHV1_NHV2_2");
         l2.newCurrentLimits1().setPermanentLimit(Double.NaN).add();
@@ -903,12 +902,19 @@ class NetworkMapControllerTest {
         network.getVariantManager().setWorkingVariant(VariantManagerConstants.INITIAL_VARIANT_ID);
 
         Network network2 = NetworkTest1Factory.create(NETWORK_2_UUID.toString());
+
+        Mockito.verifyNoInteractions(networkStoreService);
         given(networkStoreService.getNetwork(NETWORK_UUID, PreloadingStrategy.COLLECTION)).willReturn(network);
         given(networkStoreService.getNetwork(NETWORK_UUID, PreloadingStrategy.NONE)).willReturn(network);
         given(networkStoreService.getNetwork(NOT_FOUND_NETWORK_ID, PreloadingStrategy.COLLECTION)).willThrow(new PowsyblException("Network " + NOT_FOUND_NETWORK_ID + " not found"));
         given(networkStoreService.getNetwork(NOT_FOUND_NETWORK_ID, PreloadingStrategy.NONE)).willThrow(new PowsyblException("Network " + NOT_FOUND_NETWORK_ID + " not found"));
         given(networkStoreService.getNetwork(NETWORK_2_UUID, PreloadingStrategy.COLLECTION)).willReturn(network2);
         given(networkStoreService.getNetwork(NETWORK_2_UUID, PreloadingStrategy.NONE)).willReturn(network2);
+    }
+
+    @AfterAll
+    static void tearDown() {
+        Mockito.validateMockitoUsage();
     }
 
     private static void createSwitch(VoltageLevel vl, String id, SwitchKind kind, boolean open, int node1, int node2) {


### PR DESCRIPTION
Passing an empty list is now the same as not passing the parameter for `substationId`(`s`).