### PR TITLE
remove getCurrentLimits for toMap for Lines

### DIFF
--- a/src/main/java/org/gridsuite/network/map/dto/mapper/LineInfosMapper.java
+++ b/src/main/java/org/gridsuite/network/map/dto/mapper/LineInfosMapper.java
@@ -123,9 +123,6 @@ public final class LineInfosMapper {
                 .p2(nullIfNan(terminal2.getP()))
                 .i1(nullIfNan(ElementUtils.computeIntensity(terminal1, dcPowerFactor)))
                 .i2(nullIfNan(ElementUtils.computeIntensity(terminal2, dcPowerFactor)));
-
-        line.getCurrentLimits1().ifPresent(limits1 -> builder.currentLimits1(toMapDataCurrentLimits(limits1)));
-        line.getCurrentLimits2().ifPresent(limits2 -> builder.currentLimits2(toMapDataCurrentLimits(limits2)));
         builder.operatingStatus(toOperatingStatus(line));
 
         return builder.build();

--- a/src/test/resources/lines-map-data.json
+++ b/src/test/resources/lines-map-data.json
@@ -6,32 +6,7 @@
     "terminal1Connected": true,
     "terminal2Connected": true,
     "p1": 1.1,
-    "p2": 3.33,
-    "currentLimits1": {
-      "permanentLimit": 700.4,
-      "temporaryLimits": [
-        {
-          "name": "IT5",
-          "value": 250.0,
-          "acceptableDuration": 300
-        }
-      ]
-    },
-    "currentLimits2": {
-      "permanentLimit": 800.8,
-      "temporaryLimits": [
-        {
-          "name": "IT20",
-          "value": 300.0,
-          "acceptableDuration": 1200
-        },
-        {
-          "name": "IT10",
-          "value": 200.0,
-          "acceptableDuration": 600
-        }
-      ]
-    }
+    "p2": 3.33
   },
   {
     "id": "NHV1_NHV2_2",

--- a/src/test/resources/lines-map-data.json
+++ b/src/test/resources/lines-map-data.json
@@ -13,32 +13,7 @@
     "voltageLevelId1": "VLHV1",
     "voltageLevelId2": "VLHV2",
     "terminal1Connected": true,
-    "terminal2Connected": true,
-    "currentLimits1": {
-      "permanentLimit": 220.0,
-      "temporaryLimits": [
-        {
-          "name": "temporary2",
-          "value": 70.0,
-          "acceptableDuration": 150
-        },
-        {
-          "name": "temporary1",
-          "value": 50.0,
-          "acceptableDuration": 100
-        }
-      ]
-    },
-    "currentLimits2": {
-      "permanentLimit": 320.0,
-      "temporaryLimits": [
-        {
-          "name": "temporary1",
-          "value": 130.0,
-          "acceptableDuration": 200
-        }
-      ]
-    }
+    "terminal2Connected": true
   },
   {
     "id": "LINE3",

--- a/src/test/resources/partial-lines-map-data.json
+++ b/src/test/resources/partial-lines-map-data.json
@@ -15,32 +15,7 @@
     "voltageLevelId1": "VLHV1",
     "voltageLevelId2": "VLHV2",
     "terminal1Connected": true,
-    "terminal2Connected": true,
-    "currentLimits1": {
-      "permanentLimit": 220.0,
-      "temporaryLimits": [
-        {
-          "name": "temporary2",
-          "value": 70.0,
-          "acceptableDuration": 150
-        },
-        {
-          "name": "temporary1",
-          "value": 50.0,
-          "acceptableDuration": 100
-        }
-      ]
-    },
-    "currentLimits2": {
-      "permanentLimit": 320.0,
-      "temporaryLimits": [
-        {
-          "name": "temporary1",
-          "value": 130.0,
-          "acceptableDuration": 200
-        }
-      ]
-    }
+    "terminal2Connected": true
   },
   {
     "id": "NHV1_NHV2_1",

--- a/src/test/resources/partial-lines-map-data.json
+++ b/src/test/resources/partial-lines-map-data.json
@@ -24,31 +24,6 @@
     "terminal1Connected": true,
     "terminal2Connected": true,
     "p1": 1.1,
-    "p2": 3.33,
-    "currentLimits1": {
-      "permanentLimit": 700.4,
-      "temporaryLimits": [
-        {
-          "name": "IT5",
-          "value": 250.0,
-          "acceptableDuration": 300
-        }
-      ]
-    },
-    "currentLimits2": {
-      "permanentLimit": 800.8,
-      "temporaryLimits": [
-        {
-          "name": "IT20",
-          "value": 300.0,
-          "acceptableDuration": 1200
-        },
-        {
-          "name": "IT10",
-          "value": 200.0,
-          "acceptableDuration": 600
-        }
-      ]
-    }
+    "p2": 3.33
   }
 ]


### PR DESCRIPTION
current limits are not needed when loading the map for geo data
(with lazy loadings of the limits they wont be loaded when opening a study)