### PR TITLE
add consumptions and generations in buses tab

### DIFF
--- a/src/main/java/org/gridsuite/network/map/dto/definition/bus/BusTabInfos.java
+++ b/src/main/java/org/gridsuite/network/map/dto/definition/bus/BusTabInfos.java
@@ -35,6 +35,10 @@ public class BusTabInfos extends ElementInfosWithProperties {
 
     private Double nominalVoltage;
 
+    private Double generations;
+
+    private Double consumptions;
+
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private Country country;
 

--- a/src/main/java/org/gridsuite/network/map/dto/mapper/BusInfosMapper.java
+++ b/src/main/java/org/gridsuite/network/map/dto/mapper/BusInfosMapper.java
@@ -6,14 +6,15 @@
  */
 package org.gridsuite.network.map.dto.mapper;
 
-import com.powsybl.iidm.network.Bus;
-import com.powsybl.iidm.network.Identifiable;
+import com.powsybl.iidm.network.*;
 import org.gridsuite.network.map.dto.ElementInfos;
 import org.gridsuite.network.map.dto.InfoTypeParameters;
 import org.gridsuite.network.map.dto.definition.bus.BusTabInfos;
 import org.gridsuite.network.map.dto.utils.ElementUtils;
 
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Stream;
 
 import static org.gridsuite.network.map.dto.InfoTypeParameters.QUERY_PARAM_LOAD_NETWORK_COMPONENTS;
 import static org.gridsuite.network.map.dto.utils.ElementUtils.*;
@@ -45,6 +46,8 @@ public final class BusInfosMapper {
                 .voltageLevelId(bus.getVoltageLevel().getId())
                 .nominalVoltage(bus.getVoltageLevel().getNominalV())
                 .country(mapCountry(bus.getVoltageLevel().getSubstation().orElse(null)))
+                .generations(Math.abs(computeGenerations(bus)))
+                .consumptions(Math.abs(computeConsumptions(bus)))
                 .properties(getProperties(bus))
                 .substationProperties(bus.getVoltageLevel().getSubstation().map(ElementUtils::getProperties).orElse(null))
                 .voltageLevelProperties(getProperties(bus.getVoltageLevel()));
@@ -56,5 +59,20 @@ public final class BusInfosMapper {
         }
 
         return builder.build();
+    }
+
+    private static double computeConsumptions(Bus bus) {
+        AtomicReference<Double> consumptions = new AtomicReference<>(0.);
+        bus.getLoadStream().forEach(load -> consumptions.updateAndGet(v -> v + load.getTerminal().getP()));
+        return consumptions.get();
+    }
+
+    private static double computeGenerations(Bus bus) {
+        AtomicReference<Double> generations = new AtomicReference<>(0.);
+        Stream.concat(bus.getGeneratorStream(), bus.getBatteryStream()).forEach(injection ->
+                generations.updateAndGet(v -> v + injection.getTerminal().getP())
+
+        );
+        return generations.get();
     }
 }

--- a/src/main/java/org/gridsuite/network/map/dto/mapper/BusInfosMapper.java
+++ b/src/main/java/org/gridsuite/network/map/dto/mapper/BusInfosMapper.java
@@ -8,6 +8,7 @@ package org.gridsuite.network.map.dto.mapper;
 
 import com.powsybl.iidm.network.Bus;
 import com.powsybl.iidm.network.Identifiable;
+import com.powsybl.iidm.network.Load;
 import org.gridsuite.network.map.dto.ElementInfos;
 import org.gridsuite.network.map.dto.InfoTypeParameters;
 import org.gridsuite.network.map.dto.definition.bus.BusTabInfos;
@@ -62,19 +63,15 @@ public final class BusInfosMapper {
     }
 
     private static double computeConsumptions(Bus bus) {
-        return absOrNull(bus.getLoadStream()
+        return Math.abs(bus.getLoadStream()
                 .filter(injection -> !Double.isNaN(injection.getTerminal().getP()))
                 .mapToDouble(injection -> injection.getTerminal().getP()).sum());
     }
 
     private static double computeGenerations(Bus bus) {
-        return absOrNull(Stream.concat(bus.getGeneratorStream(), bus.getBatteryStream())
+        return Math.abs(Stream.concat(bus.getGeneratorStream(), bus.getBatteryStream())
                 .filter(injection -> !Double.isNaN(injection.getTerminal().getP()))
                 .mapToDouble(injection -> injection.getTerminal().getP())
                 .sum());
-    }
-
-    private static Double absOrNull(Double value) {
-        return value != null ? Math.abs(value) : null;
     }
 }

--- a/src/main/java/org/gridsuite/network/map/dto/mapper/BusInfosMapper.java
+++ b/src/main/java/org/gridsuite/network/map/dto/mapper/BusInfosMapper.java
@@ -6,14 +6,14 @@
  */
 package org.gridsuite.network.map.dto.mapper;
 
-import com.powsybl.iidm.network.*;
+import com.powsybl.iidm.network.Bus;
+import com.powsybl.iidm.network.Identifiable;
 import org.gridsuite.network.map.dto.ElementInfos;
 import org.gridsuite.network.map.dto.InfoTypeParameters;
 import org.gridsuite.network.map.dto.definition.bus.BusTabInfos;
 import org.gridsuite.network.map.dto.utils.ElementUtils;
 
 import java.util.Optional;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 
 import static org.gridsuite.network.map.dto.InfoTypeParameters.QUERY_PARAM_LOAD_NETWORK_COMPONENTS;
@@ -46,8 +46,8 @@ public final class BusInfosMapper {
                 .voltageLevelId(bus.getVoltageLevel().getId())
                 .nominalVoltage(bus.getVoltageLevel().getNominalV())
                 .country(mapCountry(bus.getVoltageLevel().getSubstation().orElse(null)))
-                .generations(Math.abs(computeGenerations(bus)))
-                .consumptions(Math.abs(computeConsumptions(bus)))
+                .generations(computeGenerations(bus))
+                .consumptions(computeConsumptions(bus))
                 .properties(getProperties(bus))
                 .substationProperties(bus.getVoltageLevel().getSubstation().map(ElementUtils::getProperties).orElse(null))
                 .voltageLevelProperties(getProperties(bus.getVoltageLevel()));
@@ -62,17 +62,19 @@ public final class BusInfosMapper {
     }
 
     private static double computeConsumptions(Bus bus) {
-        AtomicReference<Double> consumptions = new AtomicReference<>(0.);
-        bus.getLoadStream().forEach(load -> consumptions.updateAndGet(v -> v + load.getTerminal().getP()));
-        return consumptions.get();
+        return absOrNull(bus.getLoadStream()
+                .filter(injection -> !Double.isNaN(injection.getTerminal().getP()))
+                .mapToDouble(injection -> injection.getTerminal().getP()).sum());
     }
 
     private static double computeGenerations(Bus bus) {
-        AtomicReference<Double> generations = new AtomicReference<>(0.);
-        Stream.concat(bus.getGeneratorStream(), bus.getBatteryStream()).forEach(injection ->
-                generations.updateAndGet(v -> v + injection.getTerminal().getP())
+        return absOrNull(Stream.concat(bus.getGeneratorStream(), bus.getBatteryStream())
+                .filter(injection -> !Double.isNaN(injection.getTerminal().getP()))
+                .mapToDouble(injection -> injection.getTerminal().getP())
+                .sum());
+    }
 
-        );
-        return generations.get();
+    private static Double absOrNull(Double value) {
+        return value != null ? Math.abs(value) : null;
     }
 }

--- a/src/main/java/org/gridsuite/network/map/dto/mapper/BusInfosMapper.java
+++ b/src/main/java/org/gridsuite/network/map/dto/mapper/BusInfosMapper.java
@@ -8,7 +8,6 @@ package org.gridsuite.network.map.dto.mapper;
 
 import com.powsybl.iidm.network.Bus;
 import com.powsybl.iidm.network.Identifiable;
-import com.powsybl.iidm.network.Load;
 import org.gridsuite.network.map.dto.ElementInfos;
 import org.gridsuite.network.map.dto.InfoTypeParameters;
 import org.gridsuite.network.map.dto.definition.bus.BusTabInfos;

--- a/src/test/java/org/gridsuite/network/map/NetworkMapControllerTest.java
+++ b/src/test/java/org/gridsuite/network/map/NetworkMapControllerTest.java
@@ -1287,13 +1287,11 @@ public class NetworkMapControllerTest {
         AtomicInteger i = new AtomicInteger();
         network2.getGeneratorStream().forEach(generator -> {
             i.getAndIncrement();
-            System.out.println(generator.getId());
             generator.getTerminal().setP(10 * i.get());
         });
         AtomicInteger j = new AtomicInteger();
         network2.getLoadStream().forEach(loadEquipment -> {
             j.getAndIncrement();
-            System.out.println(loadEquipment.getId());
             loadEquipment.getTerminal().setP(5 * j.get());
         });
 

--- a/src/test/java/org/gridsuite/network/map/NetworkMapControllerTest.java
+++ b/src/test/java/org/gridsuite/network/map/NetworkMapControllerTest.java
@@ -41,6 +41,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 
 import static org.gridsuite.network.map.dto.InfoTypeParameters.QUERY_PARAM_BUS_ID_TO_ICC_VALUES;
@@ -1282,6 +1283,17 @@ public class NetworkMapControllerTest {
         network.getVariantManager().setWorkingVariant(VariantManagerConstants.INITIAL_VARIANT_ID);
 
         Network network2 = NetworkTest1Factory.create(NETWORK_2_UUID.toString());
+        // add P on generator and loads on voltageLevel1 to test buses view
+        AtomicInteger i = new AtomicInteger();
+        network2.getGeneratorStream().forEach(generator -> {
+            i.getAndIncrement();
+            generator.getTerminal().setP(10 * i.get());
+        });
+        AtomicInteger j = new AtomicInteger();
+        network2.getLoadStream().forEach(loadEquipment -> {
+            j.getAndIncrement();
+            loadEquipment.getTerminal().setP(5 * j.get());
+        });
 
         Mockito.verifyNoInteractions(networkStoreService);
         given(networkStoreService.getNetwork(NETWORK_UUID, PreloadingStrategy.ALL_COLLECTIONS_NEEDED_FOR_BUS_VIEW)).willReturn(network);
@@ -1690,6 +1702,7 @@ public class NetworkMapControllerTest {
         MvcResult mvcResult = mvc.perform(post("/v1/networks/{networkUuid}/all", networkUuid).queryParams(queryParams).contentType(MediaType.APPLICATION_JSON).content(objectMapper.writeValueAsString(body)))
             .andExpect(status().isOk())
             .andReturn();
+        System.out.println(mvcResult.getResponse().getContentAsString());
         JSONAssert.assertEquals(expectedJson, mvcResult.getResponse().getContentAsString(), JSONCompareMode.NON_EXTENSIBLE);
     }
 

--- a/src/test/java/org/gridsuite/network/map/NetworkMapControllerTest.java
+++ b/src/test/java/org/gridsuite/network/map/NetworkMapControllerTest.java
@@ -1465,7 +1465,6 @@ public class NetworkMapControllerTest {
                         .queryParam(QUERY_PARAM_VARIANT_ID, variantId))
                 .andExpect(status().isOk())
                 .andReturn();
-        System.out.println(res.getResponse().getContentAsString());
         JSONAssert.assertEquals(expectedJson, res.getResponse().getContentAsString(), JSONCompareMode.NON_EXTENSIBLE);
     }
 
@@ -1474,7 +1473,6 @@ public class NetworkMapControllerTest {
                         .queryParam(QUERY_PARAM_VARIANT_ID, variantId))
                 .andExpect(status().isOk())
                 .andReturn();
-        System.out.println(res.getResponse().getContentAsString());
         JSONAssert.assertEquals(expectedJson, res.getResponse().getContentAsString(), JSONCompareMode.NON_EXTENSIBLE);
     }
 
@@ -1483,7 +1481,6 @@ public class NetworkMapControllerTest {
                         .queryParam(QUERY_PARAM_VARIANT_ID, variantId))
                 .andExpect(status().isOk())
                 .andReturn();
-        System.out.println(res.getResponse().getContentAsString());
         JSONAssert.assertEquals(expectedJson, res.getResponse().getContentAsString(), JSONCompareMode.NON_EXTENSIBLE);
     }
 
@@ -1702,7 +1699,6 @@ public class NetworkMapControllerTest {
         MvcResult mvcResult = mvc.perform(post("/v1/networks/{networkUuid}/all", networkUuid).queryParams(queryParams).contentType(MediaType.APPLICATION_JSON).content(objectMapper.writeValueAsString(body)))
             .andExpect(status().isOk())
             .andReturn();
-        System.out.println(mvcResult.getResponse().getContentAsString());
         JSONAssert.assertEquals(expectedJson, mvcResult.getResponse().getContentAsString(), JSONCompareMode.NON_EXTENSIBLE);
     }
 

--- a/src/test/java/org/gridsuite/network/map/NetworkMapControllerTest.java
+++ b/src/test/java/org/gridsuite/network/map/NetworkMapControllerTest.java
@@ -1287,11 +1287,13 @@ public class NetworkMapControllerTest {
         AtomicInteger i = new AtomicInteger();
         network2.getGeneratorStream().forEach(generator -> {
             i.getAndIncrement();
+            System.out.println(generator.getId());
             generator.getTerminal().setP(10 * i.get());
         });
         AtomicInteger j = new AtomicInteger();
         network2.getLoadStream().forEach(loadEquipment -> {
             j.getAndIncrement();
+            System.out.println(loadEquipment.getId());
             loadEquipment.getTerminal().setP(5 * j.get());
         });
 
@@ -1465,6 +1467,7 @@ public class NetworkMapControllerTest {
                         .queryParam(QUERY_PARAM_VARIANT_ID, variantId))
                 .andExpect(status().isOk())
                 .andReturn();
+        System.out.println(res.getResponse().getContentAsString());
         JSONAssert.assertEquals(expectedJson, res.getResponse().getContentAsString(), JSONCompareMode.NON_EXTENSIBLE);
     }
 
@@ -1473,6 +1476,7 @@ public class NetworkMapControllerTest {
                         .queryParam(QUERY_PARAM_VARIANT_ID, variantId))
                 .andExpect(status().isOk())
                 .andReturn();
+        System.out.println(res.getResponse().getContentAsString());
         JSONAssert.assertEquals(expectedJson, res.getResponse().getContentAsString(), JSONCompareMode.NON_EXTENSIBLE);
     }
 
@@ -1481,6 +1485,7 @@ public class NetworkMapControllerTest {
                         .queryParam(QUERY_PARAM_VARIANT_ID, variantId))
                 .andExpect(status().isOk())
                 .andReturn();
+        System.out.println(res.getResponse().getContentAsString());
         JSONAssert.assertEquals(expectedJson, res.getResponse().getContentAsString(), JSONCompareMode.NON_EXTENSIBLE);
     }
 

--- a/src/test/resources/all-data-in-variant.json
+++ b/src/test/resources/all-data-in-variant.json
@@ -2456,7 +2456,7 @@
       "connectedComponentNum": 0,
       "voltageLevelId": "VLGEN",
       "nominalVoltage": 24.0,
-      "generations": "NaN",
+      "generations": 25.0,
       "consumptions": 0.0,
       "country": "FR",
       "substationProperties": {
@@ -2501,7 +2501,7 @@
       "voltageLevelId": "VLLOAD",
       "nominalVoltage": 150.0,
       "generations": 0.0,
-      "consumptions": "NaN"
+      "consumptions": 0.0
     },
     {
       "id": "VLNEW2_0",
@@ -2512,7 +2512,7 @@
       "voltageLevelId": "VLNEW2",
       "nominalVoltage": 225.0,
       "generations": 0.0,
-      "consumptions": "NaN",
+      "consumptions": 0.0,
       "country": "FR",
       "substationProperties": {
         "Country": "FR"

--- a/src/test/resources/all-data-in-variant.json
+++ b/src/test/resources/all-data-in-variant.json
@@ -2456,6 +2456,8 @@
       "connectedComponentNum": 0,
       "voltageLevelId": "VLGEN",
       "nominalVoltage": 24.0,
+      "generations": "NaN",
+      "consumptions": 0.0,
       "country": "FR",
       "substationProperties": {
         "Country": "FR"
@@ -2472,6 +2474,8 @@
       "connectedComponentNum": 0,
       "voltageLevelId": "VLHV1",
       "nominalVoltage": 380.0,
+      "generations": 0.0,
+      "consumptions": 0.0,
       "country": "FR",
       "substationProperties": {
         "Country": "FR"
@@ -2484,7 +2488,9 @@
       "synchronousComponentNum": 0,
       "connectedComponentNum": 0,
       "voltageLevelId": "VLHV2",
-      "nominalVoltage": 380.0
+      "nominalVoltage": 380.0,
+      "generations": 0.0,
+      "consumptions": 0.0
     },
     {
       "id": "VLLOAD_0",
@@ -2493,7 +2499,9 @@
       "synchronousComponentNum": 2,
       "connectedComponentNum": 2,
       "voltageLevelId": "VLLOAD",
-      "nominalVoltage": 150.0
+      "nominalVoltage": 150.0,
+      "generations": 0.0,
+      "consumptions": "NaN"
     },
     {
       "id": "VLNEW2_0",
@@ -2503,6 +2511,8 @@
       "connectedComponentNum": 0,
       "voltageLevelId": "VLNEW2",
       "nominalVoltage": 225.0,
+      "generations": 0.0,
+      "consumptions": "NaN",
       "country": "FR",
       "substationProperties": {
         "Country": "FR"
@@ -2519,6 +2529,8 @@
       "connectedComponentNum": 0,
       "voltageLevelId": "VLGEN3",
       "nominalVoltage": 24.0,
+      "generations": 0.0,
+      "consumptions": 0.0,
       "country": "FR",
       "substationProperties": {
         "Country": "FR"
@@ -2532,6 +2544,8 @@
       "connectedComponentNum": 1,
       "voltageLevelId": "VLGEN4",
       "nominalVoltage": 24.0,
+      "generations": 0.0,
+      "consumptions": 0.0,
       "country": "FR"
     },
     {
@@ -2542,6 +2556,8 @@
       "connectedComponentNum": 1,
       "voltageLevelId": "VLGEN7",
       "nominalVoltage": 24.0,
+      "generations": 0.0,
+      "consumptions": 0.0,
       "country": "FR"
     }
   ],

--- a/src/test/resources/all-data-without-optionals.json
+++ b/src/test/resources/all-data-without-optionals.json
@@ -2206,7 +2206,7 @@
       "angle": "NaN",
       "voltageLevelId": "VLGEN",
       "nominalVoltage": 24.0,
-      "generations": "NaN",
+      "generations": 25.0,
       "consumptions": 0.0,
       "country": "FR",
       "substationProperties": {
@@ -2245,7 +2245,7 @@
       "voltageLevelId": "VLLOAD",
       "nominalVoltage": 150.0,
       "generations": 0.0,
-      "consumptions": "NaN"
+      "consumptions": 0.0
     },
     {
       "id": "VLNEW2_0",
@@ -2254,7 +2254,7 @@
       "voltageLevelId": "VLNEW2",
       "nominalVoltage": 225.0,
       "generations": 0.0,
-      "consumptions": "NaN",
+      "consumptions": 0.0,
       "country": "FR",
       "substationProperties": {
         "Country": "FR"

--- a/src/test/resources/all-data-without-optionals.json
+++ b/src/test/resources/all-data-without-optionals.json
@@ -2206,6 +2206,8 @@
       "angle": "NaN",
       "voltageLevelId": "VLGEN",
       "nominalVoltage": 24.0,
+      "generations": "NaN",
+      "consumptions": 0.0,
       "country": "FR",
       "substationProperties": {
         "Country": "FR"
@@ -2220,6 +2222,8 @@
       "angle": "NaN",
       "voltageLevelId": "VLHV1",
       "nominalVoltage": 380.0,
+      "generations": 0.0,
+      "consumptions": 0.0,
       "country": "FR",
       "substationProperties": {
         "Country": "FR"
@@ -2230,14 +2234,18 @@
       "v": "NaN",
       "angle": "NaN",
       "voltageLevelId": "VLHV2",
-      "nominalVoltage": 380.0
+      "nominalVoltage": 380.0,
+      "generations": 0.0,
+      "consumptions": 0.0
     },
     {
       "id": "VLLOAD_0",
       "v": "NaN",
       "angle": "NaN",
       "voltageLevelId": "VLLOAD",
-      "nominalVoltage": 150.0
+      "nominalVoltage": 150.0,
+      "generations": 0.0,
+      "consumptions": "NaN"
     },
     {
       "id": "VLNEW2_0",
@@ -2245,6 +2253,8 @@
       "angle": "NaN",
       "voltageLevelId": "VLNEW2",
       "nominalVoltage": 225.0,
+      "generations": 0.0,
+      "consumptions": "NaN",
       "country": "FR",
       "substationProperties": {
         "Country": "FR"
@@ -2259,6 +2269,8 @@
       "angle": "NaN",
       "voltageLevelId": "VLGEN3",
       "nominalVoltage": 24.0,
+      "generations": 0.0,
+      "consumptions": 0.0,
       "country": "FR",
       "substationProperties": {
         "Country": "FR"
@@ -2270,6 +2282,8 @@
       "angle": "NaN",
       "voltageLevelId": "VLGEN4",
       "nominalVoltage": 24.0,
+      "generations": 0.0,
+      "consumptions": 0.0,
       "country": "FR"
     },
     {
@@ -2278,6 +2292,8 @@
       "angle": "NaN",
       "voltageLevelId": "VLGEN7",
       "nominalVoltage": 24.0,
+      "generations": 0.0,
+      "consumptions": 0.0,
       "country": "FR"
     }
   ],

--- a/src/test/resources/all-data.json
+++ b/src/test/resources/all-data.json
@@ -2434,7 +2434,7 @@
       "connectedComponentNum": 0,
       "voltageLevelId": "VLGEN",
       "nominalVoltage": 24.0,
-      "generations": "NaN",
+      "generations": 25.0,
       "consumptions": 0.0,
       "country": "FR",
       "substationProperties": {
@@ -2479,7 +2479,7 @@
       "voltageLevelId": "VLLOAD",
       "nominalVoltage": 150.0,
       "generations": 0.0,
-      "consumptions": "NaN"
+      "consumptions": 0.0
     },
     {
       "id": "VLNEW2_0",
@@ -2490,7 +2490,7 @@
       "voltageLevelId": "VLNEW2",
       "nominalVoltage": 225.0,
       "generations": 0.0,
-      "consumptions": "NaN",
+      "consumptions": 0.0,
       "country": "FR",
       "substationProperties": {
         "Country": "FR"

--- a/src/test/resources/all-data.json
+++ b/src/test/resources/all-data.json
@@ -2434,6 +2434,8 @@
       "connectedComponentNum": 0,
       "voltageLevelId": "VLGEN",
       "nominalVoltage": 24.0,
+      "generations": "NaN",
+      "consumptions": 0.0,
       "country": "FR",
       "substationProperties": {
         "Country": "FR"
@@ -2450,6 +2452,8 @@
       "connectedComponentNum": 0,
       "voltageLevelId": "VLHV1",
       "nominalVoltage": 380.0,
+      "generations": 0.0,
+      "consumptions": 0.0,
       "country": "FR",
       "substationProperties": {
         "Country": "FR"
@@ -2462,7 +2466,9 @@
       "synchronousComponentNum": 0,
       "connectedComponentNum": 0,
       "voltageLevelId": "VLHV2",
-      "nominalVoltage": 380.0
+      "nominalVoltage": 380.0,
+      "generations": 0.0,
+      "consumptions": 0.0
     },
     {
       "id": "VLLOAD_0",
@@ -2471,7 +2477,9 @@
       "synchronousComponentNum": 2,
       "connectedComponentNum": 2,
       "voltageLevelId": "VLLOAD",
-      "nominalVoltage": 150.0
+      "nominalVoltage": 150.0,
+      "generations": 0.0,
+      "consumptions": "NaN"
     },
     {
       "id": "VLNEW2_0",
@@ -2481,6 +2489,8 @@
       "connectedComponentNum": 0,
       "voltageLevelId": "VLNEW2",
       "nominalVoltage": 225.0,
+      "generations": 0.0,
+      "consumptions": "NaN",
       "country": "FR",
       "substationProperties": {
         "Country": "FR"
@@ -2497,6 +2507,8 @@
       "connectedComponentNum": 0,
       "voltageLevelId": "VLGEN3",
       "nominalVoltage": 24.0,
+      "generations": 0.0,
+      "consumptions": 0.0,
       "country": "FR",
       "substationProperties": {
         "Country": "FR"
@@ -2510,6 +2522,8 @@
       "connectedComponentNum": 1,
       "voltageLevelId": "VLGEN4",
       "nominalVoltage": 24.0,
+      "generations": 0.0,
+      "consumptions": 0.0,
       "country": "FR"
     },
     {
@@ -2520,6 +2534,8 @@
       "connectedComponentNum": 1,
       "voltageLevelId": "VLGEN7",
       "nominalVoltage": 24.0,
+      "generations": 0.0,
+      "consumptions": 0.0,
       "country": "FR"
     }
   ],

--- a/src/test/resources/buses-tab-data.json
+++ b/src/test/resources/buses-tab-data.json
@@ -7,6 +7,8 @@
     "connectedComponentNum": 0,
     "voltageLevelId": "n9828181c-7977-4592-ba19-008976e4254e_voltageLevel1",
     "nominalVoltage": 400.0,
-    "country": "FR"
+    "country": "FR",
+    "consumptions": 5.0,
+    "generations": 10.0
   }
 ]

--- a/src/test/resources/partial-all-data-in-variant.json
+++ b/src/test/resources/partial-all-data-in-variant.json
@@ -411,6 +411,8 @@
       "connectedComponentNum": 0,
       "voltageLevelId": "VLGEN3",
       "nominalVoltage": 24.0,
+      "generations": 0.0,
+      "consumptions": 0.0,
       "country": "FR",
       "substationProperties": {
         "Country": "FR"

--- a/src/test/resources/partial-all-data.json
+++ b/src/test/resources/partial-all-data.json
@@ -386,6 +386,8 @@
       "connectedComponentNum": 0,
       "voltageLevelId": "VLGEN3",
       "nominalVoltage": 24.0,
+      "generations": 0.0,
+      "consumptions": 0.0,
       "country": "FR",
       "substationProperties": {
         "Country": "FR"

--- a/src/test/resources/partial-all-map-data-no-redundant-lines.json
+++ b/src/test/resources/partial-all-map-data-no-redundant-lines.json
@@ -429,6 +429,8 @@
       "connectedComponentNum": 0,
       "voltageLevelId": "VLGEN3",
       "nominalVoltage": 24.0,
+      "generations": 0.0,
+      "consumptions": 0.0,
       "country": "FR",
       "substationProperties": {
         "Country": "FR"


### PR DESCRIPTION
## PR Summary
- compute generations as sum of P for generators and batteries
- compute consumptions as sum of P for loads
- set generations and consumptions in buses tab with absolute value



