### PR TITLE
feat(generator modification): add P and Q measurements

### DIFF
--- a/src/main/java/org/gridsuite/network/map/dto/definition/generator/GeneratorFormInfos.java
+++ b/src/main/java/org/gridsuite/network/map/dto/definition/generator/GeneratorFormInfos.java
@@ -88,5 +88,9 @@ public class GeneratorFormInfos extends ElementInfosWithProperties {
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private String busOrBusbarSectionId;
 
+    @JsonInclude(JsonInclude.Include.NON_ABSENT)
+    private Optional<MeasurementsInfos> measurementP;
 
+    @JsonInclude(JsonInclude.Include.NON_ABSENT)
+    private Optional<MeasurementsInfos> measurementQ;
 }

--- a/src/main/java/org/gridsuite/network/map/dto/mapper/GeneratorInfosMapper.java
+++ b/src/main/java/org/gridsuite/network/map/dto/mapper/GeneratorInfosMapper.java
@@ -190,7 +190,8 @@ public final class GeneratorInfosMapper {
                 builder.reactiveCapabilityCurvePoints(getReactiveCapabilityCurvePoints(capabilityCurve.getPoints()));
             }
         }
-
+        builder.measurementP(ExtensionUtils.toMeasurement(generator, Type.ACTIVE_POWER, 0))
+                .measurementQ(ExtensionUtils.toMeasurement(generator, Type.REACTIVE_POWER, 0));
         builder.connectablePosition(ExtensionUtils.toMapConnectablePosition(generator, 0));
         return builder.build();
     }

--- a/src/test/resources/generator-map-data.json
+++ b/src/test/resources/generator-map-data.json
@@ -38,5 +38,13 @@
     "connectionPosition": 0,
     "connectionName": "feederName"
   },
-  "busOrBusbarSectionId": "NGEN"
+  "busOrBusbarSectionId": "NGEN",
+  "measurementP": {
+    "value": 50.0,
+    "validity": true
+  },
+  "measurementQ": {
+    "value": 5.0,
+    "validity": true
+  }
 }


### PR DESCRIPTION
## PR Summary
<!-- Briefly summarize the changes: what it was before, what it is after, and any important notes for reviewers. -->
When we retrieve Generator data, we want to include the measurement value and validity for active/reactive power.

2 use cases:
- to create new columns with these 2 values in the spreadsheet
- to get and display a "previous value" for them when we edit a Generator modification



