### PR TITLE
add fictitious injection in bus tab view

### DIFF
--- a/src/main/java/org/gridsuite/network/map/dto/definition/bus/BusTabInfos.java
+++ b/src/main/java/org/gridsuite/network/map/dto/definition/bus/BusTabInfos.java
@@ -38,6 +38,12 @@ public class BusTabInfos extends ElementInfosWithProperties {
     private Double load;
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
+    private Double fictitiousP0;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private Double fictitiousQ0;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     private Country country;
 
     @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/src/main/java/org/gridsuite/network/map/dto/mapper/BusInfosMapper.java
+++ b/src/main/java/org/gridsuite/network/map/dto/mapper/BusInfosMapper.java
@@ -8,6 +8,7 @@ package org.gridsuite.network.map.dto.mapper;
 
 import com.powsybl.iidm.network.Bus;
 import com.powsybl.iidm.network.Identifiable;
+import com.powsybl.iidm.network.TopologyKind;
 import org.gridsuite.network.map.dto.ElementInfos;
 import org.gridsuite.network.map.dto.InfoTypeParameters;
 import org.gridsuite.network.map.dto.definition.bus.BusTabInfos;
@@ -40,6 +41,7 @@ public final class BusInfosMapper {
 
     private static BusTabInfos toTabInfos(Identifiable<?> identifiable, boolean shouldLoadNetworkComponents) {
         Bus bus = (Bus) identifiable;
+        TopologyKind topologyKind = bus.getNetwork().getVoltageLevel(bus.getVoltageLevel().getId()).getTopologyKind();
         BusTabInfos.BusTabInfosBuilder<?, ?> builder = BusTabInfos.builder().id(bus.getId())
                 .angle(bus.getAngle())
                 .v(bus.getV())
@@ -50,7 +52,9 @@ public final class BusInfosMapper {
                 .load(computeLoad(bus))
                 .properties(getProperties(bus))
                 .substationProperties(bus.getVoltageLevel().getSubstation().map(ElementUtils::getProperties).orElse(null))
-                .voltageLevelProperties(getProperties(bus.getVoltageLevel()));
+                .voltageLevelProperties(getProperties(bus.getVoltageLevel()))
+                .fictitiousP0(topologyKind == TopologyKind.NODE_BREAKER ? bus.getFictitiousP0() : null)
+                .fictitiousQ0(topologyKind == TopologyKind.NODE_BREAKER ? bus.getFictitiousQ0() : null);
 
         if (shouldLoadNetworkComponents) {
             builder

--- a/src/main/java/org/gridsuite/network/map/services/NetworkMapService.java
+++ b/src/main/java/org/gridsuite/network/map/services/NetworkMapService.java
@@ -332,7 +332,12 @@ public class NetworkMapService {
 
     public ElementInfos getElementInfos(UUID networkUuid, String variantId, ElementType elementType, InfoTypeParameters infoTypeParameters, String elementId) {
         Network network = getNetwork(networkUuid, PreloadingStrategy.NONE, variantId);
-        Identifiable<?> identifiable = network.getIdentifiable(elementId);
+        Identifiable<?> identifiable;
+        if (elementType == ElementType.BUS) {
+            identifiable = network.getBusView().getBus(elementId);
+        } else {
+            identifiable = network.getIdentifiable(elementId);
+        }
         if (identifiable == null) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND);
         }

--- a/src/test/resources/all-data-in-variant.json
+++ b/src/test/resources/all-data-in-variant.json
@@ -2546,6 +2546,8 @@
       "nominalVoltage": 24.0,
       "generation": 0.0,
       "load": 0.0,
+      "fictitiousP0" : 0.0,
+      "fictitiousQ0" : 0.0,
       "country": "FR"
     },
     {
@@ -2558,6 +2560,8 @@
       "nominalVoltage": 24.0,
       "generation": 0.0,
       "load": 0.0,
+      "fictitiousP0" : 0.0,
+      "fictitiousQ0" : 0.0,
       "country": "FR"
     }
   ],

--- a/src/test/resources/all-data-without-optionals.json
+++ b/src/test/resources/all-data-without-optionals.json
@@ -2284,6 +2284,8 @@
       "nominalVoltage": 24.0,
       "generation": 0.0,
       "load": 0.0,
+      "fictitiousP0" : 0.0,
+      "fictitiousQ0" : 0.0,
       "country": "FR"
     },
     {
@@ -2294,6 +2296,8 @@
       "nominalVoltage": 24.0,
       "generation": 0.0,
       "load": 0.0,
+      "fictitiousP0" : 0.0,
+      "fictitiousQ0" : 0.0,
       "country": "FR"
     }
   ],

--- a/src/test/resources/all-data.json
+++ b/src/test/resources/all-data.json
@@ -2524,6 +2524,8 @@
       "nominalVoltage": 24.0,
       "generation": 0.0,
       "load": 0.0,
+      "fictitiousP0" : 0.0,
+      "fictitiousQ0" : 0.0,
       "country": "FR"
     },
     {
@@ -2536,6 +2538,8 @@
       "nominalVoltage": 24.0,
       "generation": 0.0,
       "load": 0.0,
+      "fictitiousP0" : 0.0,
+      "fictitiousQ0" : 0.0,
       "country": "FR"
     }
   ],

--- a/src/test/resources/buses-tab-data.json
+++ b/src/test/resources/buses-tab-data.json
@@ -9,6 +9,8 @@
     "nominalVoltage": 400.0,
     "country": "FR",
     "load": 5.0,
-    "generation": 10.0
+    "generation": 10.0,
+    "fictitiousP0": 0.0,
+    "fictitiousQ0": 0.0
   }
 ]


### PR DESCRIPTION
## PR Summary
Allows displaying fictitious injection (P0,Q0) in the Bus tab view



