### PR TITLE
Add support for measurement properties in JSON data and DTO mapping

### DIFF
--- a/src/main/java/org/gridsuite/network/map/dto/definition/extension/MeasurementsInfos.java
+++ b/src/main/java/org/gridsuite/network/map/dto/definition/extension/MeasurementsInfos.java
@@ -11,6 +11,8 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.util.Map;
+
 /**
  * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
  */
@@ -21,5 +23,8 @@ public class MeasurementsInfos {
     private Double value;
 
     private boolean validity;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private Map<String, String> properties;
 }
 

--- a/src/main/java/org/gridsuite/network/map/dto/utils/ExtensionUtils.java
+++ b/src/main/java/org/gridsuite/network/map/dto/utils/ExtensionUtils.java
@@ -10,8 +10,11 @@ import org.springframework.lang.Nullable;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.function.Function;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 public final class ExtensionUtils {
     private ExtensionUtils() { }
@@ -81,7 +84,18 @@ public final class ExtensionUtils {
                         .stream()
                         .filter(m -> m.getSide() == null || m.getSide().getNum() - 1 == index)
                         .findFirst())
-                .map(m -> MeasurementsInfos.builder().value(m.getValue()).validity(m.isValid()).build());
+                .map(m -> MeasurementsInfos.builder()
+                        .value(m.getValue())
+                        .validity(m.isValid())
+                        .properties(getMeasurementProperties(m))
+                        .build());
+    }
+
+    private static Map<String, String> getMeasurementProperties(@NonNull final Measurement measurement) {
+        Map<String, String> properties = measurement.getPropertyNames()
+                .stream()
+                .collect(Collectors.toMap(Function.identity(), measurement::getProperty));
+        return properties.isEmpty() ? null : properties;
     }
 
     public static Optional<TapChangerDiscreteMeasurementsInfos> toMeasurementTapChanger(@NonNull final Connectable<?> connectable, @NonNull final DiscreteMeasurement.Type type,

--- a/src/test/java/org/gridsuite/network/map/NetworkMapControllerTest.java
+++ b/src/test/java/org/gridsuite/network/map/NetworkMapControllerTest.java
@@ -389,7 +389,7 @@ public class NetworkMapControllerTest {
                 .add();
         gen.newExtension(MeasurementsAdder.class).add();
         Measurements<Generator> genMeasurements = gen.getExtension(Measurements.class);
-        genMeasurements.newMeasurement().setType(Measurement.Type.ACTIVE_POWER).setValid(true).setValue(50).add();
+        genMeasurements.newMeasurement().setType(Measurement.Type.ACTIVE_POWER).setValid(true).setValue(50).putProperty("validity", "0").add();
         genMeasurements.newMeasurement().setType(Measurement.Type.REACTIVE_POWER).setValid(true).setValue(5).add();
 
         gen.newExtension(InjectionObservabilityAdder.class)

--- a/src/test/resources/all-data-in-variant.json
+++ b/src/test/resources/all-data-in-variant.json
@@ -1746,7 +1746,10 @@
       },
       "measurementP": {
         "value": 50.0,
-        "validity": true
+        "validity": true,
+        "properties": {
+          "validity": "0"
+        }
       },
       "measurementQ": {
         "value": 5.0,

--- a/src/test/resources/all-data-without-optionals.json
+++ b/src/test/resources/all-data-without-optionals.json
@@ -1521,7 +1521,10 @@
       },
       "measurementP": {
         "value": 50.0,
-        "validity": true
+        "validity": true,
+        "properties": {
+          "validity": "0"
+        }
       },
       "measurementQ": {
         "value": 5.0,

--- a/src/test/resources/all-data.json
+++ b/src/test/resources/all-data.json
@@ -1746,7 +1746,10 @@
       },
       "measurementP": {
         "value": 50.0,
-        "validity": true
+        "validity": true,
+        "properties": {
+          "validity": "0"
+        }
       },
       "measurementQ": {
         "value": 5.0,

--- a/src/test/resources/generator-map-data.json
+++ b/src/test/resources/generator-map-data.json
@@ -41,7 +41,10 @@
   "busOrBusbarSectionId": "NGEN",
   "measurementP": {
     "value": 50.0,
-    "validity": true
+    "validity": true,
+    "properties": {
+      "validity": "0"
+    }
   },
   "measurementQ": {
     "value": 5.0,

--- a/src/test/resources/generators-tab-data-without-optionals.json
+++ b/src/test/resources/generators-tab-data-without-optionals.json
@@ -40,7 +40,10 @@
     },
     "measurementP": {
       "value": 50.0,
-      "validity": true
+      "validity": true,
+      "properties": {
+        "validity": "0"
+      }
     },
     "measurementQ": {
       "value": 5.0,

--- a/src/test/resources/generators-tab-data.json
+++ b/src/test/resources/generators-tab-data.json
@@ -44,7 +44,10 @@
     },
     "measurementP": {
       "value": 50.0,
-      "validity": true
+      "validity": true,
+      "properties": {
+        "validity": "0"
+      }
     },
     "measurementQ": {
       "value": 5.0,


### PR DESCRIPTION
## PR Summary
<!-- Briefly summarize the changes: what it was before, what it is after, and any important notes for reviewers. -->


**Add measurement properties to MeasurementsInfos**
**Context**
When equipment infos are returned, we include measurement infos (value and validity). However, measurements in the powsybl measurements extension can also carry properties.

**Change**
Added a properties field (Map<String, String>) to MeasurementsInfos, serialized only when present (@JsonInclude(NON_NULL), consistent with the other properties fields in the codebase).
Populated it in ExtensionUtils.toMeasurement(...) via a small helper that reads the measurement's getPropertyNames() / getProperty(...) and returns null when empty (mirrors the existing ElementUtils.getProperties convention).
Since all equipment mappers (Generator, Load, Line, Branch, Battery, Transformers, Converter Stations, ShuntCompensator, StaticVarCompensator, BusBarSection) go through the single toMeasurement method, they all benefit automatically with no per-mapper changes.

Tests
Added a measurement property in the test fixture and updated the affected expected JSON resources.
